### PR TITLE
Upgrade to the newest opentelemetry API

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -12,7 +12,7 @@ const exporter = new PrometheusExporter({port: 9464, startServer: true}, () => {
 
 const meterProvider = new MeterProvider({
   exporter,
-  interval: 2000
+  interval: 5000
 })
 
 require('opentelemetry-node-metrics')(meterProvider)

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -19,9 +19,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
-      "integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
       "peer": true,
       "engines": {
         "node": ">=8.0.0"
@@ -65,6 +65,21 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+      "integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.0.1",
+        "@opentelemetry/semantic-conventions": "1.0.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.1.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-metrics-base": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.27.0.tgz",
@@ -80,21 +95,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/resources": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
-      "integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.0.1",
-        "@opentelemetry/semantic-conventions": "1.0.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.1.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -117,9 +117,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
-      "integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
       "peer": true
     },
     "@opentelemetry/api-metrics": {
@@ -145,6 +145,15 @@
         "@opentelemetry/sdk-metrics-base": "0.27.0"
       }
     },
+    "@opentelemetry/resources": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+      "integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
+      "requires": {
+        "@opentelemetry/core": "1.0.1",
+        "@opentelemetry/semantic-conventions": "1.0.1"
+      }
+    },
     "@opentelemetry/sdk-metrics-base": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.27.0.tgz",
@@ -154,17 +163,6 @@
         "@opentelemetry/core": "1.0.1",
         "@opentelemetry/resources": "1.0.1",
         "lodash.merge": "^4.6.2"
-      },
-      "dependencies": {
-        "@opentelemetry/resources": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
-          "integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
-          "requires": {
-            "@opentelemetry/core": "1.0.1",
-            "@opentelemetry/semantic-conventions": "1.0.1"
-          }
-        }
       }
     },
     "@opentelemetry/semantic-conventions": {

--- a/index.js
+++ b/index.js
@@ -1,19 +1,9 @@
 module.exports = function setupNodeMetrics (meterProvider, config) {
-  config = config || {}
-  config.prefix = config.prefix ? config.prefix : ''
-  config.labels = config.labels ? config.labels : {}
+  config = config ? {...config} : {}
+  config.prefix = config.prefix || ''
+  config.labels = config.labels || {}
 
-  let meter = meterProvider.getMeter('opentelemetry-node-metrics')
-
-  // keep opentelemetry compatibility with v0.24.x
-  if (!meter.createObservableGauge) {
-    meter = {
-      createObservableGauge: meter.createValueObserver.bind(meter),
-      createHistogram: meter.createValueRecorder.bind(meter),
-      createCounter: meter.createCounter.bind(meter),
-      createUpDownCounter: meter.createUpDownCounter.bind(meter)
-    }
-  }
+  const meter = meterProvider.getMeter('opentelemetry-node-metrics')
 
   require('./metrics/version')(meter, config)
   require('./metrics/processStartTime')(meter, config)

--- a/metrics/gc.js
+++ b/metrics/gc.js
@@ -13,15 +13,15 @@ module.exports = (meter, {prefix, labels, gcDurationBuckets}) => {
   })
 
   const kinds = {}
-  kinds[constants.NODE_PERFORMANCE_GC_MAJOR] = histogram.bind({...labels, kind: 'major'})
-  kinds[constants.NODE_PERFORMANCE_GC_MINOR] = histogram.bind({...labels, kind: 'minor'})
-  kinds[constants.NODE_PERFORMANCE_GC_INCREMENTAL] = histogram.bind({...labels, kind: 'incremental'}) // eslint-disable-line max-len
-  kinds[constants.NODE_PERFORMANCE_GC_WEAKCB] = histogram.bind({...labels, kind: 'weakcb'})
+  kinds[constants.NODE_PERFORMANCE_GC_MAJOR] = {...labels, kind: 'major'}
+  kinds[constants.NODE_PERFORMANCE_GC_MINOR] = {...labels, kind: 'minor'}
+  kinds[constants.NODE_PERFORMANCE_GC_INCREMENTAL] = {...labels, kind: 'incremental'}
+  kinds[constants.NODE_PERFORMANCE_GC_WEAKCB] = {...labels, kind: 'weakcb'}
 
-  const obs = new PerformanceObserver(list => {
+  const obs = new PerformanceObserver((list) => {
     const entry = list.getEntries()[0]
     // Convert duration from milliseconds to seconds
-    kinds[entry.detail ? entry.detail.kind : entry.kind].record(entry.duration / 1000)
+    histogram.record(entry.duration / 1000, kinds[entry.detail ? entry.detail.kind : entry.kind])
   })
 
   // We do not expect too many gc events per second, so we do not use buffering

--- a/metrics/heapSizeAndUsed.js
+++ b/metrics/heapSizeAndUsed.js
@@ -5,23 +5,35 @@ const NODEJS_HEAP_SIZE_USED = 'nodejs_heap_size_used_bytes'
 const NODEJS_EXTERNAL_MEMORY = 'nodejs_external_memory_bytes'
 
 module.exports = (meter, {labels, prefix}) => {
-  const heapSizeTotal = meter.createObservableGauge(prefix + NODEJS_HEAP_SIZE_TOTAL, {
+  let stats
+  function getStats () {
+    if (stats !== undefined) return stats
+    stats = safeMemoryUsage() || false
+    setTimeout(() => { stats = undefined }, 1000).unref()
+    return stats
+  }
+
+  meter.createObservableGauge(prefix + NODEJS_HEAP_SIZE_TOTAL, {
     description: 'Process heap size from Node.js in bytes.'
-  }).bind(labels)
+  }, (observable) => {
+    if (!getStats()) return
+    observable.observe(stats.heapTotal, labels)
+  })
 
-  const heapSizeUsed = meter.createObservableGauge(prefix + NODEJS_HEAP_SIZE_USED, {
+  meter.createObservableGauge(prefix + NODEJS_HEAP_SIZE_USED, {
     description: 'Process heap size used from Node.js in bytes.'
-  }).bind(labels)
+  }, (observable) => {
+    if (!getStats()) return
+    observable.observe(stats.heapUsed, labels)
+  })
 
-  const externalMemUsed = meter.createObservableGauge(prefix + NODEJS_EXTERNAL_MEMORY, {
+  meter.createObservableGauge(prefix + NODEJS_EXTERNAL_MEMORY, {
     description: 'Node.js external memory size in bytes.'
-  }, () => {
-    const memUsage = safeMemoryUsage()
-    if (!memUsage) return
-    heapSizeTotal.update(memUsage.heapTotal)
-    heapSizeUsed.update(memUsage.heapUsed)
-    if (memUsage.external !== undefined) externalMemUsed.update(memUsage.external)
-  }).bind(labels)
+  }, (observable) => {
+    if (!getStats()) return
+    if (stats.external === undefined) return
+    observable.observe(stats.external, labels)
+  })
 }
 
 module.exports.metricNames = [

--- a/metrics/helpers/processMetricsHelpers.js
+++ b/metrics/helpers/processMetricsHelpers.js
@@ -12,9 +12,9 @@ function createAggregatorByObjectName () {
     }
 
     for (const [key, value] of current) {
-      const instrument = all.get(key) || metric.bind({...labels, type: key})
-      instrument.update(value)
-      all.set(key, instrument)
+      const metricLabels = all.get(key) || {...labels, type: key}
+      metric.observe(value, metricLabels)
+      all.set(key, metricLabels)
     }
   }
 }

--- a/metrics/osMemoryHeap.js
+++ b/metrics/osMemoryHeap.js
@@ -4,14 +4,14 @@ const safeMemoryUsage = require('./helpers/safeMemoryUsage')
 const PROCESS_RESIDENT_MEMORY = 'process_resident_memory_bytes'
 
 function notLinuxVariant (meter, {prefix, labels}) {
-  const boundMeter = meter.createObservableGauge(prefix + PROCESS_RESIDENT_MEMORY, {
+  meter.createObservableGauge(prefix + PROCESS_RESIDENT_MEMORY, {
     description: 'Resident memory size in bytes.'
-  }, () => {
+  }, (observable) => {
     const memUsage = safeMemoryUsage()
     // I don't think the other things returned from
     // `process.memoryUsage()` is relevant to a standard export
-    if (memUsage) boundMeter.update(memUsage.rss)
-  }).bind(labels)
+    if (memUsage) observable.observe(memUsage.rss, labels)
+  })
 }
 
 module.exports = process.platform === 'linux'

--- a/metrics/processHandles.js
+++ b/metrics/processHandles.js
@@ -9,18 +9,18 @@ module.exports = (meter, {prefix, labels}) => {
   if (typeof process._getActiveHandles !== 'function') return
 
   const aggregateByObjectName = createAggregatorByObjectName()
-  const activeHandlesMetric = meter.createObservableGauge(prefix + NODEJS_ACTIVE_HANDLES, {
+  meter.createObservableGauge(prefix + NODEJS_ACTIVE_HANDLES, {
     description: 'Number of active libuv handles grouped by handle type. Every handle type is C++ class name.' // eslint-disable-line max-len
-  }, () => {
-    aggregateByObjectName(activeHandlesMetric, labels, process._getActiveHandles())
+  }, (observable) => {
+    aggregateByObjectName(observable, labels, process._getActiveHandles())
   })
 
-  const boundTotalMetric = meter.createObservableGauge(prefix + NODEJS_ACTIVE_HANDLES_TOTAL, {
+  meter.createObservableGauge(prefix + NODEJS_ACTIVE_HANDLES_TOTAL, {
     description: 'Total number of active handles.'
-  }, () => {
+  }, (observable) => {
     const handles = process._getActiveHandles()
-    boundTotalMetric.update(handles.length)
-  }).bind(labels)
+    observable.observe(handles.length, labels)
+  })
 }
 
 module.exports.metricNames = [

--- a/metrics/processMaxFileDescriptors.js
+++ b/metrics/processMaxFileDescriptors.js
@@ -25,7 +25,7 @@ module.exports = (meter, {prefix, labels}) => {
 
   meter.createUpDownCounter(prefix + PROCESS_MAX_FDS, {
     description: 'Maximum number of open file descriptors.'
-  }).bind(labels).add(maxFds)
+  }).add(maxFds, labels)
 }
 
 module.exports.metricNames = [PROCESS_MAX_FDS]

--- a/metrics/processOpenFileDescriptors.js
+++ b/metrics/processOpenFileDescriptors.js
@@ -6,18 +6,18 @@ const PROCESS_OPEN_FDS = 'process_open_fds'
 module.exports = (meter, {prefix, labels}) => {
   if (process.platform !== 'linux') return
 
-  const boundInstrument = meter.createObservableGauge(prefix + PROCESS_OPEN_FDS, {
+  meter.createObservableGauge(prefix + PROCESS_OPEN_FDS, {
     description: 'Number of open file descriptors.'
-  }, () => {
+  }, (observable) => {
     try {
       const fds = fs.readdirSync('/proc/self/fd')
       // Minus 1 to not count the fd that was used by readdirSync(),
       // it's now closed.
-      boundInstrument.update(fds.length - 1)
+      observable.observe(fds.length - 1, labels)
     } catch {
       // noop
     }
-  }).bind(labels)
+  })
 }
 
 module.exports.metricNames = [PROCESS_OPEN_FDS]

--- a/metrics/processRequests.js
+++ b/metrics/processRequests.js
@@ -9,17 +9,17 @@ module.exports = (meter, {prefix, labels}) => {
   if (typeof process._getActiveRequests !== 'function') return
 
   const aggregateByObjectName = createAggregatorByObjectName()
-  const activeRequestsMetric = meter.createObservableGauge(prefix + NODEJS_ACTIVE_REQUESTS, {
+  meter.createObservableGauge(prefix + NODEJS_ACTIVE_REQUESTS, {
     description: 'Number of active libuv requests grouped by request type. Every request type is C++ class name.' // eslint-disable-line max-len
-  }, () => {
-    aggregateByObjectName(activeRequestsMetric, labels, process._getActiveRequests())
+  }, (observable) => {
+    aggregateByObjectName(observable, labels, process._getActiveRequests())
   })
 
-  const boundTotalRequests = meter.createObservableGauge(prefix + NODEJS_ACTIVE_REQUESTS_TOTAL, {
+  meter.createObservableGauge(prefix + NODEJS_ACTIVE_REQUESTS_TOTAL, {
     description: 'Total number of active requests.'
-  }, () => {
-    boundTotalRequests.update(process._getActiveRequests().length)
-  }).bind(labels)
+  }, (observable) => {
+    observable.observe(process._getActiveRequests().length, labels)
+  })
 }
 
 module.exports.metricNames = [

--- a/metrics/processStartTime.js
+++ b/metrics/processStartTime.js
@@ -5,7 +5,7 @@ const PROCESS_START_TIME = 'process_start_time_seconds'
 module.exports = (meter, {prefix, labels}) => {
   meter.createUpDownCounter(prefix + PROCESS_START_TIME, {
     description: 'Start time of the process since unix epoch in seconds.'
-  }).bind(labels).add(startInSeconds)
+  }).add(startInSeconds, labels)
 }
 
 module.exports.metricNames = [PROCESS_START_TIME]

--- a/metrics/version.js
+++ b/metrics/version.js
@@ -14,7 +14,7 @@ module.exports = (meter, {prefix, labels}) => {
 
   meter.createUpDownCounter(prefix + NODE_VERSION_INFO, {
     description: 'Node.js version info.'
-  }).bind(version).add(1)
+  }).add(1, version)
 }
 
 module.exports.metricNames = [NODE_VERSION_INFO]


### PR DESCRIPTION
### Changelog
- 💥 Migrate to the newest opentelemetry api. Drop compatibility with versions older than v0.27.0.
  This fixes several issues like #6 and #5 
